### PR TITLE
Add example option for proxy and external_downloader

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -208,7 +208,7 @@ description = "YouTube video downloader"
 name = "youtube-dl"
 optional = false
 python-versions = "*"
-version = "2020.3.24"
+version = "2020.6.6"
 
 [metadata]
 content-hash = "e0083d83a4c1982e0267200b18c53baa632ebdd5929d95d27883fa42b024b53b"

--- a/pornhub/download.py
+++ b/pornhub/download.py
@@ -81,6 +81,8 @@ def download_video(viewkey, name="single_videos"):
         "retries": 3,
         "nooverwrites": False,
         "continuedl": True,
+        # 'proxy': 'socks5://127.0.0.1:1086', # Uncomment this if you want to use proxy
+        # "external_downloader": "aria2c", # Uncomment this if you know how to use aria2
     }
     if is_premium:
         options["cookiefile"] = "cookie_file"

--- a/pornhub/download.py
+++ b/pornhub/download.py
@@ -81,7 +81,7 @@ def download_video(viewkey, name="single_videos"):
         "retries": 3,
         "nooverwrites": False,
         "continuedl": True,
-        # 'proxy': 'socks5://127.0.0.1:1086', # Uncomment this if you want to use proxy
+        # 'all_proxy': 'http://127.0.0.1:1087', # Uncomment this if you want to use proxy
         # "external_downloader": "aria2c", # Uncomment this if you know how to use aria2
     }
     if is_premium:


### PR DESCRIPTION
- Update youtube-dl from 2020.3.24 to 2020.6.6
- use http proxy